### PR TITLE
fix(infra): don't include node_modules in itam-edu-frontend image

### DIFF
--- a/packages/frontend/Dockerfile
+++ b/packages/frontend/Dockerfile
@@ -13,14 +13,6 @@ COPY ./packages/db ./packages/db
 COPY ./packages/api ./packages/api
 COPY ./packages/frontend ./packages/frontend
 
-# Start development server
-FROM node:22-alpine AS dev
-WORKDIR /app
-ENV NODE_ENV=development
-
-COPY --from=prepare /app .
-ENTRYPOINT npm --workspace=itam-edu-frontend run dev -- --host=0.0.0.0 --port=3000
-
 # Build for production and prune dev dependencies
 FROM node:22-alpine AS build
 WORKDIR /app

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -12,7 +12,8 @@
         "check:format": "prettier . --check",
         "lint": "prettier --check . && eslint ."
     },
-    "dependencies": {
+    "dependencies": {},
+    "devDependencies": {
         "@elysiajs/eden": "^1.2.0",
         "@phosphor-icons/web": "^2.1.1",
         "@sinclair/typebox": "^0.34.14",
@@ -25,9 +26,7 @@
         "date-fns": "^4.1.0",
         "fast-deep-equal": "^3.1.3",
         "itam-edu-common": "file:../common",
-        "sortablejs": "^1.15.6"
-    },
-    "devDependencies": {
+        "sortablejs": "^1.15.6",
         "@eslint/compat": "^1.2.3",
         "@sveltejs/kit": "^2.9.0",
         "@sveltejs/vite-plugin-svelte": "^5.0.0",


### PR DESCRIPTION
Vite tree-shakes all dependencies and puts whatt is left into the `build` folder